### PR TITLE
Increase code coverage

### DIFF
--- a/tests/BytesTest.php
+++ b/tests/BytesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+
+final class BytesTest extends TestCase
+{
+    public function testBytesToHex(): void
+    {
+        $bytes = new Bytes("cow");
+        $hex = $bytes->getHexString();
+        $expected = "636f77";
+        $this->assertEquals($hex, $expected);
+
+        // Should get same result from toString implementation
+        $toString = strval($bytes);
+        $this->assertEquals($toString, $expected);
+    }
+}

--- a/tests/Crypto/CryptoRngTest.php
+++ b/tests/Crypto/CryptoRngTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Crypto;
+
+use PHPUnit\Framework\TestCase;
+
+final class CryptoRngTest extends TestCase
+{
+    public function testGetInstance(): void
+    {
+        $instance1 = CryptoRng::getInstance();
+        $instance2 = CryptoRng::getInstance();
+        // Assert about deep equality
+        $this->assertTrue($instance1 === $instance2);
+    }
+
+    public function testRandomBytesLength(): void
+    {
+        $rng = CryptoRng::getInstance();
+        $bytes = $rng->randomBytes(12);
+        $this->assertEquals(strlen($bytes->getByteString()), 12);
+    }
+}

--- a/tests/DocumentPartsTest.php
+++ b/tests/DocumentPartsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+
+final class DocumentPartsTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $preamble = new Bytes("aaa");
+        $header = new Bytes("bbb");
+        $ciphertext = new Bytes("ccc");
+        $parts = new DocumentParts($preamble, $header, $ciphertext);
+        $this->assertEquals($parts->getPreamble(), $preamble);
+        $this->assertEquals($parts->getHeader(), $header);
+        $this->assertEquals($parts->getCiphertext(), $ciphertext);
+    }
+}

--- a/tests/EncryptedDocumentTest.php
+++ b/tests/EncryptedDocumentTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+
+final class EncryptedDocumentTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $fields = ["foo" => new Bytes("bar")];
+        $edek = new Bytes("edek");
+        $document = new EncryptedDocument($fields, $edek);
+        $this->assertEquals($document->getEdek(), $edek);
+        $this->assertEquals($document->getEncryptedFields(), $fields);
+    }
+}

--- a/tests/PlaintextDocumentTest.php
+++ b/tests/PlaintextDocumentTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+
+final class PlaintextDocumentTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $fields = ["foo" => new Bytes("bar")];
+        $edek = new Bytes("edek");
+        $document = new PlaintextDocument($fields, $edek);
+        $this->assertEquals($document->getEdek(), $edek);
+        $this->assertEquals($document->getDecryptedFields(), $fields);
+    }
+}

--- a/tests/Proto/DataControlPlatformHeaderTest.php
+++ b/tests/Proto/DataControlPlatformHeaderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Crypto;
+
+use PHPUnit\Framework\TestCase;
+use Proto\IronCoreLabs\DataControlPlatformHeader;
+
+final class DataControlPlatformHeaderTest extends TestCase
+{
+    public function testHeader(): void
+    {
+        $documentId = "ID";
+        $segmentId = 421;
+        $header = new DataControlPlatformHeader();
+        $header->setDocumentId($documentId);
+        $header->setSegmentId($segmentId);
+        $headerDocumentId = $header->getDocumentId();
+        $headerSegmentId = $header->getSegmentId();
+        $this->assertEquals($documentId, $headerDocumentId);
+        $this->assertEquals($segmentId, $headerSegmentId);
+    }
+}

--- a/tests/Proto/SaasShieldHeaderTest.php
+++ b/tests/Proto/SaasShieldHeaderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Crypto;
+
+use PHPUnit\Framework\TestCase;
+use Proto\IronCoreLabs\SaaSShieldHeader;
+
+final class SaasShieldHeaderTest extends TestCase
+{
+    public function testHeader(): void
+    {
+        $tenantId = "foo";
+        $header = new SaaSShieldHeader();
+        $header->setTenantId($tenantId);
+        $headerTenantId = $header->getTenantId();
+        $this->assertEquals($tenantId, $headerTenantId);
+    }
+}

--- a/tests/Proto/V3DocumentHeaderTest.php
+++ b/tests/Proto/V3DocumentHeaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Crypto;
+
+use PHPUnit\Framework\TestCase;
+use Proto\IronCoreLabs\DataControlPlatformHeader;
+use Proto\IronCoreLabs\SaaSShieldHeader;
+use Proto\IronCoreLabs\V3DocumentHeader;
+
+final class V3DocumentHeaderTest extends TestCase
+{
+    public function testDcpHeader(): void
+    {
+        $documentId = "ID";
+        $segmentId = 421;
+        $dcp = new DataControlPlatformHeader();
+        $dcp->setDocumentId($documentId);
+        $dcp->setSegmentId($segmentId);
+        $sig = "signature";
+        $header = new V3DocumentHeader();
+        $header->setDataControl($dcp);
+        $header->setSig($sig);
+        $this->assertEquals($header->getSig(), $sig);
+        $this->assertEquals($header->getDataControl(), $dcp);
+        $this->assertTrue($header->hasDataControl());
+        $this->assertEquals($header->getHeader(), "data_control");
+    }
+
+    public function testSaasShieldHeader(): void
+    {
+        $tenantId = "tenant";
+        $shield = new SaaSShieldHeader();
+        $shield->setTenantId($tenantId);
+        $sig = "signature";
+        $header = new V3DocumentHeader();
+        $header->setSaasShield($shield);
+        $header->setSig($sig);
+        $this->assertEquals($header->getSig(), $sig);
+        $this->assertEquals($header->getSaasShield(), $shield);
+        $this->assertTrue($header->hasSaasShield());
+        $this->assertEquals($header->getHeader(), "saas_shield");
+    }
+}

--- a/tests/RequestMetadataTest.php
+++ b/tests/RequestMetadataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+
+final class RequestMetadataTest extends TestCase
+{
+    public function testRequestMetadataTenantId(): void
+    {
+        $tenantId = "my-tenant";
+        $metadata = new RequestMetadata($tenantId, new IclFields("foo"), []);
+        $this->assertEquals($metadata->getTenantId(), $tenantId);
+    }
+}

--- a/tests/Rest/UnwrapKeyRequestTest.php
+++ b/tests/Rest/UnwrapKeyRequestTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Rest;
+
+use IronCore\Bytes;
+use IronCore\IclFields;
+use IronCore\RequestMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class UnwrapKeyRequestTest extends TestCase
+{
+    public function testJsonData(): void
+    {
+        $iclFields = new IclFields("requesting-id");
+        $metadata = new RequestMetadata("my-tenant", $iclFields, []);
+        $edek = new Bytes("bar");
+        $request = new UnwrapKeyRequest($metadata, $edek);
+        $post = $request->getJsonData();
+        $expected =
+            '{
+                "tenantId":"my-tenant",
+                "iclFields":{
+                    "requestingId":"requesting-id",
+                    "dataLabel":null,
+                    "sourceIp":null,
+                    "objectId":null,
+                    "requestId":null
+                },
+                "customFields":{},
+                "encryptedDocumentKey":"YmFy"
+            }';
+        // Generated JSON won't have extra lines or spaces
+        $strippedExpected = str_replace(["\n", " "], "", $expected);
+        $this->assertEquals($post, $strippedExpected);
+    }
+}

--- a/tests/Rest/WrapKeyRequestTest.php
+++ b/tests/Rest/WrapKeyRequestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Rest;
+
+use IronCore\Bytes;
+use IronCore\IclFields;
+use IronCore\RequestMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class WrapKeyRequestTest extends TestCase
+{
+    public function testJsonData(): void
+    {
+        $iclFields = new IclFields("requesting-id");
+        $metadata = new RequestMetadata("my-tenant", $iclFields, []);
+        $edek = new Bytes("bar");
+        $request = new WrapKeyRequest($metadata);
+        $post = $request->getJsonData();
+        $expected =
+            '{
+                "tenantId":"my-tenant",
+                "iclFields":{
+                    "requestingId":"requesting-id",
+                    "dataLabel":null,
+                    "sourceIp":null,
+                    "objectId":null,
+                    "requestId":null
+                },
+                "customFields":{}
+            }';
+        // Generated JSON won't have extra lines or spaces
+        $strippedExpected = str_replace(["\n", " "], "", $expected);
+        $this->assertEquals($post, $strippedExpected);
+    }
+}

--- a/tests/TenantSecurityClientTest.php
+++ b/tests/TenantSecurityClientTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use IronCore\Exception\TenantSecurityException;
+use PHPUnit\Framework\TestCase;
+
+final class TenantSecurityClientTest extends TestCase
+{
+
+    public function testFailedToMakeWrapRequest(): void
+    {
+        $tsc = new TenantSecurityClient("localhost:99999", "");
+        $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
+        $this->expectException(TenantSecurityException::class);
+        $this->expectExceptionMessage("Failed to make a request to the TSP.");
+        $tsc->encrypt(["/" => new Bytes("")], $metadata);
+    }
+
+    public function testFailedToMakeUnwrapRequest(): void
+    {
+        $tsc = new TenantSecurityClient("localhost:99999", "");
+        $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
+        $this->expectException(TenantSecurityException::class);
+        $this->expectExceptionMessage("Failed to make a request to the TSP.");
+        $tsc->decrypt(new EncryptedDocument(["/" => new Bytes("")], new Bytes("edek")), $metadata);
+    }
+}

--- a/tests/TenantSecurityRequestTest.php
+++ b/tests/TenantSecurityRequestTest.php
@@ -16,4 +16,23 @@ final class TenantSecurityRequestTest extends TestCase
         $this->expectException(TenantSecurityException::class);
         $request->makeJsonRequest("/", "");
     }
+
+    public function testFailedWrapRequest(): void
+    {
+        $request = new TenantSecurityRequest("localhost:99999", "");
+        $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
+        $this->expectException(TenantSecurityException::class);
+        $this->expectExceptionMessage("Failed to make a request to the TSP.");
+        $request->wrapKey($metadata);
+    }
+
+    public function testFailedUnwrapRequest(): void
+    {
+        $request = new TenantSecurityRequest("localhost:99999", "");
+        $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
+        $edek = new Bytes("boo");
+        $this->expectException(TenantSecurityException::class);
+        $this->expectExceptionMessage("Failed to make a request to the TSP.");
+        $request->unwrapKey($edek, $metadata);
+    }
 }

--- a/tests/V3HeaderSignatureTest.php
+++ b/tests/V3HeaderSignatureTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore;
+
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+final class V3HeaderSignatureTest extends TestCase
+{
+    public function testFromBytesFailure(): void
+    {
+        $badBytes = new Bytes("badBytes");
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage("Bytes were not a V3HeaderSignature because they were not the correct length");
+        V3HeaderSignature::fromBytes($badBytes);
+    }
+}


### PR DESCRIPTION
This adds tests for all functions and lines on all classes other than ones that have to talk to a TSP (mainly TenantSecurityRequest and TenantSecurityClient). The one exception is an Exception in Aes::encrypt that could possibly only get thrown on different systems.
We could consider some sort of abstract class or possibly mocking to be able to test the functions that rely on curl.

This will put us above the 80% threshold for CI