### PR TITLE
Add throttling error code

### DIFF
--- a/src/Exception/TenantSecurityException.php
+++ b/src/Exception/TenantSecurityException.php
@@ -94,6 +94,11 @@ class TenantSecurityException extends Exception
                     "KmsUnreachable: Request to KMS failed because KMS was unreachable.",
                     $code
                 );
+            case 209:
+                return new KmsException(
+                    "KmsThrottled: Request to KMS failed because KMS throttled the Tenant Security Proxy.",
+                    $code
+                );
             case 301:
                 return new SecurityEventException(
                     "SecurityEventRejected: Tenant Security Proxy could not accept the security event.",

--- a/tests/Exception/TenantSecurityExceptionTest.php
+++ b/tests/Exception/TenantSecurityExceptionTest.php
@@ -43,6 +43,7 @@ final class TenantSecurityExceptionTest extends TestCase
         $this->assertEquals(self::createExceptionForCode(206)->getCode(), 206);
         $this->assertEquals(self::createExceptionForCode(207)->getCode(), 207);
         $this->assertEquals(self::createExceptionForCode(208)->getCode(), 208);
+        $this->assertEquals(self::createExceptionForCode(209)->getCode(), 209);
         $this->assertEquals(self::createExceptionForCode(301)->getCode(), 301);
     }
 


### PR DESCRIPTION
Tsp 4.4.0+ has the throttling error code. This adds support to correctly deserialize that error to surface it out to the caller.