### PR TITLE
Fix bug with EventMetadata.timestampMillis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Fix bug with null EventMetadata.timestampMillis.
+
 ## v0.2.2
 
 - Add method to encrypt a batch of files with a single call to the TSP.

--- a/src/EventMetadata.php
+++ b/src/EventMetadata.php
@@ -44,7 +44,6 @@ class EventMetadata extends RequestMetadata
      */
     public function getPostData(): array
     {
-
         return [
             "tenantId" => $this->tenantId,
             "iclFields" => $this->iclFields,

--- a/src/EventMetadata.php
+++ b/src/EventMetadata.php
@@ -27,6 +27,9 @@ class EventMetadata extends RequestMetadata
         array $customFields,
         int $timestampMillis = null
     ) {
+        if ($timestampMillis == null) {
+            $timestampMillis = intval(microtime(true)*1000);
+        };
         $this->tenantId = $tenantId;
         $this->iclFields = $iclFields;
         $this->customFields = $customFields;
@@ -41,6 +44,7 @@ class EventMetadata extends RequestMetadata
      */
     public function getPostData(): array
     {
+
         return [
             "tenantId" => $this->tenantId,
             "iclFields" => $this->iclFields,


### PR DESCRIPTION
Fixes an issue with null timestampMillis because TSP requires it to be present