### PR TITLE
Change visibility of important class methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ index.php
 **.phar
 **.cache
 coverage/
+*.html
+*.css
+*.js
+*.phpdoc

--- a/src/BatchEncryptedDocuments.php
+++ b/src/BatchEncryptedDocuments.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * A batch of documents which have been encrypted.
  */
-class BatchEncryptedDocuments
+final class BatchEncryptedDocuments
 {
     /**
      * @var EncryptedDocument[]

--- a/src/BatchPlaintextDocuments.php
+++ b/src/BatchPlaintextDocuments.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * A batch of documents which have been decrypted.
  */
-class BatchPlaintextDocuments
+final class BatchPlaintextDocuments
 {
     /**
      * @var PlaintextDocument[]

--- a/src/Bytes.php
+++ b/src/Bytes.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 /**
  * Wrapper around a string that contains raw bytes
  */
-class Bytes
+final class Bytes
 {
     /**
      * @var string

--- a/src/Crypto/AesConstants.php
+++ b/src/Crypto/AesConstants.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IronCore\Crypto;
+
+// Starting in php 8.2, these constants can be in the Aes trait. Currently our minimum
+// supported version is 7.4, so this workaround is necessary.
+final class AesConstants
+{
+    public const IV_LEN = 12;
+    public const TAG_LEN = 16;
+    /** The size of the fixed length portion of the header (version, magic, size) */
+    public const DOCUMENT_HEADER_META_LENGTH = 7;
+    /** Max IronCore header size. Equals 256 * 255 + 255 since we do a 2 byte size. */
+    public const MAX_HEADER_SIZE = 65535;
+}

--- a/src/DocumentParts.php
+++ b/src/DocumentParts.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * A parsed IronCore encrypted document
  */
-class DocumentParts
+final class DocumentParts
 {
     /**
      * @var Bytes

--- a/src/EncryptedDocument.php
+++ b/src/EncryptedDocument.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * A set of fields which has been encrypted.
  */
-class EncryptedDocument
+final class EncryptedDocument
 {
     /**
      * @var \IronCore\Bytes[]

--- a/src/EventMetadata.php
+++ b/src/EventMetadata.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * RequestMetadata with an optional `timestampMillis` referencing when a security event took place.
  */
-class EventMetadata extends RequestMetadata
+final class EventMetadata extends RequestMetadata
 {
     /**
      * @var string Unique ID of tenant that is performing the operation.

--- a/src/Exception/CryptoException.php
+++ b/src/Exception/CryptoException.php
@@ -7,6 +7,6 @@ namespace IronCore\Exception;
 /**
  * This exception indicates a problem with encrypting, decrypting or verifying signatures.
  */
-class CryptoException extends TenantSecurityException
+final class CryptoException extends TenantSecurityException
 {
 }

--- a/src/Exception/KmsException.php
+++ b/src/Exception/KmsException.php
@@ -8,6 +8,6 @@ namespace IronCore\Exception;
  * This exception indicates a problem with the Tenant Security Proxy talking to the
  * KMS, or a problem with KMS keys.
  */
-class KmsException extends TenantSecurityException
+final class KmsException extends TenantSecurityException
 {
 }

--- a/src/Exception/SecurityEventException.php
+++ b/src/Exception/SecurityEventException.php
@@ -7,6 +7,6 @@ namespace IronCore\Exception;
 /**
  * This indicates a problem with logging a security event to the TSP.
  */
-class SecurityEventException extends TenantSecurityException
+final class SecurityEventException extends TenantSecurityException
 {
 }

--- a/src/Exception/TspServiceException.php
+++ b/src/Exception/TspServiceException.php
@@ -7,6 +7,6 @@ namespace IronCore\Exception;
 /**
  * This indicates a problem from the Tenant Security Proxy itself (such as invalid API key).
  */
-class TspServiceException extends TenantSecurityException
+final class TspServiceException extends TenantSecurityException
 {
 }

--- a/src/IclFieldsWithEvent.php
+++ b/src/IclFieldsWithEvent.php
@@ -9,7 +9,7 @@ use IronCore\SecurityEvents\SecurityEvent;
 /**
  * Holds the event to pass to the Tenant Security Proxy for logging purposes.
  */
-class IclFieldsWithEvent extends IclFields
+final class IclFieldsWithEvent extends IclFields
 {
     /**
      * @var string Security event to log when calling `logSecurityEvent`

--- a/src/PlaintextDocument.php
+++ b/src/PlaintextDocument.php
@@ -7,7 +7,7 @@ namespace IronCore;
 /**
  * A decrypted document.
  */
-class PlaintextDocument
+final class PlaintextDocument
 {
     /**
      * @var Bytes[]

--- a/src/Rest/BatchUnwrapKeyRequest.php
+++ b/src/Rest/BatchUnwrapKeyRequest.php
@@ -11,7 +11,7 @@ use IronCore\Rest\IronCoreRequest;
 /**
  * Request to the Tenant Security Proxy's batch unwrap keys endpoint
  */
-class BatchUnwrapKeyRequest extends IronCoreRequest
+final class BatchUnwrapKeyRequest extends IronCoreRequest
 {
     /**
      * @var RequestMetadata

--- a/src/Rest/BatchUnwrapKeyResponse.php
+++ b/src/Rest/BatchUnwrapKeyResponse.php
@@ -11,7 +11,7 @@ use IronCore\Exception\TenantSecurityException;
 /**
  * Response from the Tenant Security Proxy's batch unwrap key endpoint
  */
-class BatchUnwrapKeyResponse
+final class BatchUnwrapKeyResponse
 {
     /**
      * @var UnwrapKeyResponse[]

--- a/src/Rest/BatchWrapKeyRequest.php
+++ b/src/Rest/BatchWrapKeyRequest.php
@@ -10,7 +10,7 @@ use IronCore\Rest\IronCoreRequest;
 /**
  * Request to the Tenant Security Proxy's batch wrap keys endpoint
  */
-class BatchWrapKeyRequest extends IronCoreRequest
+final class BatchWrapKeyRequest extends IronCoreRequest
 {
     /**
      * @var RequestMetadata

--- a/src/Rest/BatchWrapKeyResponse.php
+++ b/src/Rest/BatchWrapKeyResponse.php
@@ -11,7 +11,7 @@ use IronCore\Exception\TenantSecurityException;
 /**
  * Response from the Tenant Security Proxy's batch wrap key endpoint
  */
-class BatchWrapKeyResponse
+final class BatchWrapKeyResponse
 {
     /**
      * @var WrapKeyResponse[]

--- a/src/Rest/LogSecurityEventRequest.php
+++ b/src/Rest/LogSecurityEventRequest.php
@@ -12,7 +12,7 @@ use IronCore\SecurityEvents\SecurityEvent;
 /**
  * Request to the Tenant Security Proxy's security event logging endpoint
  */
-class LogSecurityEventRequest extends IronCoreRequest
+final class LogSecurityEventRequest extends IronCoreRequest
 {
     /**
      * @var EventMetadata

--- a/src/Rest/RekeyRequest.php
+++ b/src/Rest/RekeyRequest.php
@@ -11,7 +11,7 @@ use IronCore\Rest\IronCoreRequest;
 /**
  * Request to the Tenant Security Proxy's re-key endpoint
  */
-class RekeyRequest extends IronCoreRequest
+final class RekeyRequest extends IronCoreRequest
 {
     /**
      * @var RequestMetadata

--- a/src/Rest/RekeyResponse.php
+++ b/src/Rest/RekeyResponse.php
@@ -10,7 +10,7 @@ use IronCore\Bytes;
 /**
  * Response from the Tenant Security Proxy's re-key endpoint
  */
-class RekeyResponse
+final class RekeyResponse
 {
     /**
      * @var Bytes

--- a/src/Rest/UnwrapKeyRequest.php
+++ b/src/Rest/UnwrapKeyRequest.php
@@ -11,7 +11,7 @@ use IronCore\Rest\IronCoreRequest;
 /**
  * Request to the Tenant Security Proxy's unwrap key endpoint
  */
-class UnwrapKeyRequest extends IronCoreRequest
+final class UnwrapKeyRequest extends IronCoreRequest
 {
     /**
      * @var RequestMetadata

--- a/src/Rest/UnwrapKeyResponse.php
+++ b/src/Rest/UnwrapKeyResponse.php
@@ -10,7 +10,7 @@ use IronCore\Bytes;
 /**
  * Response from the Tenant Security Proxy's unwrap key endpoint
  */
-class UnwrapKeyResponse
+final class UnwrapKeyResponse
 {
     /**
      * @var Bytes

--- a/src/Rest/WrapKeyRequest.php
+++ b/src/Rest/WrapKeyRequest.php
@@ -10,7 +10,7 @@ use IronCore\Rest\IronCoreRequest;
 /**
  * Request to the Tenant Security Proxy's wrap key endpoint
  */
-class WrapKeyRequest extends IronCoreRequest
+final class WrapKeyRequest extends IronCoreRequest
 {
     /**
      * @var RequestMetadata

--- a/src/Rest/WrapKeyResponse.php
+++ b/src/Rest/WrapKeyResponse.php
@@ -10,7 +10,7 @@ use IronCore\Bytes;
 /**
  * Response from the Tenant Security Proxy's wrap key endpoint
  */
-class WrapKeyResponse
+final class WrapKeyResponse
 {
     /**
      * @var Bytes

--- a/src/SecurityEvents/AdminEvent.php
+++ b/src/SecurityEvents/AdminEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace IronCore\SecurityEvents;
 
-class AdminEvent extends SecurityEvent
+final class AdminEvent extends SecurityEvent
 {
     private $flatEvent;
 

--- a/src/SecurityEvents/CustomEvent.php
+++ b/src/SecurityEvents/CustomEvent.php
@@ -6,7 +6,7 @@ namespace IronCore\SecurityEvents;
 
 use InvalidArgumentException;
 
-class CustomEvent extends SecurityEvent
+final class CustomEvent extends SecurityEvent
 {
     private $flatEvent;
 

--- a/src/SecurityEvents/DataEvent.php
+++ b/src/SecurityEvents/DataEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace IronCore\SecurityEvents;
 
-class DataEvent extends SecurityEvent
+final class DataEvent extends SecurityEvent
 {
     private $flatEvent;
 

--- a/src/SecurityEvents/PeriodicEvent.php
+++ b/src/SecurityEvents/PeriodicEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace IronCore\SecurityEvents;
 
-class PeriodicEvent extends SecurityEvent
+final class PeriodicEvent extends SecurityEvent
 {
     private $flatEvent;
 

--- a/src/SecurityEvents/UserEvent.php
+++ b/src/SecurityEvents/UserEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace IronCore\SecurityEvents;
 
-class UserEvent extends SecurityEvent
+final class UserEvent extends SecurityEvent
 {
     private $flatEvent;
 

--- a/src/TenantSecurityClient.php
+++ b/src/TenantSecurityClient.php
@@ -13,8 +13,10 @@ use IronCore\SecurityEvents\SecurityEvent;
  * library will need to utilize, and a single instance of the class can be re-used for requests
  * across different tenants.
  */
-class TenantSecurityClient
+final class TenantSecurityClient extends TenantSecurityRequest
 {
+    use Aes;
+
     /**
      * @var TenantSecurityRequest
      */
@@ -47,7 +49,7 @@ class TenantSecurityClient
         $wrapResponse = $this->request->wrapKey($metadata);
         $tenantId = $metadata->getTenantId();
         $dek = $wrapResponse->getDek();
-        $encryptDocument = fn (Bytes $field): Bytes => Aes::encryptDocument(
+        $encryptDocument = fn (Bytes $field): Bytes => self::encryptDocument(
             $field,
             $tenantId,
             $dek,
@@ -62,7 +64,7 @@ class TenantSecurityClient
         $unwrapResponse = $this->request->unwrapKey($document->getEdek(), $metadata);
         $tenantId = $metadata->getTenantId();
         $dek = $unwrapResponse->getDek();
-        $encryptDocument = fn (Bytes $field): Bytes => Aes::encryptDocument(
+        $encryptDocument = fn (Bytes $field): Bytes => self::encryptDocument(
             $field,
             $tenantId,
             $dek,
@@ -99,7 +101,7 @@ class TenantSecurityClient
             $dek = $key->getDek();
             $edek = $key->getEdek();
             $document = $documents[$documentId];
-            $encryptDocumentFields = fn (Bytes $field): Bytes => Aes::encryptDocument(
+            $encryptDocumentFields = fn (Bytes $field): Bytes => self::encryptDocument(
                 $field,
                 $tenantId,
                 $dek,
@@ -126,7 +128,7 @@ class TenantSecurityClient
         $unwrapResponse = $this->request->unwrapKey($document->getEdek(), $metadata);
         $dek = $unwrapResponse->getDek();
         $encryptedFields = $document->getEncryptedFields();
-        $decryptDocumentFields = fn (Bytes $field): Bytes => Aes::decryptDocument($field, $dek);
+        $decryptDocumentFields = fn (Bytes $field): Bytes => self::decryptDocument($field, $dek);
         $decryptedFields = array_map($decryptDocumentFields, $encryptedFields);
         return new PlaintextDocument($decryptedFields, $document->getEdek());
     }
@@ -159,7 +161,7 @@ class TenantSecurityClient
             $dek = $key->getDek();
             $edek = $edeks[$documentId];
             $document = $documents[$documentId];
-            $decryptFields = fn (Bytes $field): Bytes => Aes::decryptDocument($field, $dek);
+            $decryptFields = fn (Bytes $field): Bytes => self::decryptDocument($field, $dek);
             $decryptedDocument = array_map($decryptFields, $document->getEncryptedFields());
             $decryptedDocuments[$documentId] = new PlaintextDocument($decryptedDocument, $edek);
         };

--- a/src/V3HeaderSignature.php
+++ b/src/V3HeaderSignature.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace IronCore;
 
-use IronCore\Crypto\Aes;
+use IronCore\Crypto\AesConstants;
 use UnexpectedValueException;
 
 /**
  * V3 IronCore header signature
  */
-class V3HeaderSignature
+final class V3HeaderSignature
 {
     /**
      * @var Bytes
@@ -40,12 +40,15 @@ class V3HeaderSignature
      */
     public static function fromBytes(Bytes $bytes): V3HeaderSignature
     {
-        if ($bytes->length() != Aes::IV_LEN + Aes::TAG_LEN) {
+        if ($bytes->length() != AesConstants::IV_LEN + AesConstants::TAG_LEN) {
             throw new
                 UnexpectedValueException("Bytes were not a V3HeaderSignature because they were not the correct length");
         }
 
-        return new V3HeaderSignature($bytes->byteSlice(0, Aes::IV_LEN), $bytes->byteSlice(Aes::IV_LEN, Aes::TAG_LEN));
+        return new V3HeaderSignature(
+            $bytes->byteSlice(0, AesConstants::IV_LEN),
+            $bytes->byteSlice(AesConstants::IV_LEN, AesConstants::TAG_LEN)
+        );
     }
 
     /**

--- a/tests/TenantSecurityRequestTest.php
+++ b/tests/TenantSecurityRequestTest.php
@@ -8,70 +8,81 @@ use IronCore\Exception\TenantSecurityException;
 use IronCore\SecurityEvents\UserEvent;
 use PHPUnit\Framework\TestCase;
 
+final class TestableTenantSecurityRequest extends TenantSecurityRequest
+{
+    public function __construct(string $tspAddress, string $apiKey)
+    {
+        return parent::__construct($tspAddress, $apiKey);
+    }
+}
+
 final class TenantSecurityRequestTest extends TestCase
 {
 
+    private static function callMethod(string $name, array $args)
+    {
+        $class = new \ReflectionClass('IronCore\TenantSecurityRequest');
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        $object = new TestableTenantSecurityRequest("localhost:99999", "");
+        $result = $method->invokeArgs($object, $args);
+        return $result;
+    }
+
     public function testFailedToMakeRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $this->expectException(TenantSecurityException::class);
-        $request->makeJsonRequest("/", "");
+        self::callMethod("makeJsonRequest", ["/", ""]);
     }
 
     public function testFailedWrapRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->wrapKey($metadata);
+        self::callMethod("wrapKey", [$metadata]);
     }
 
     public function testFailedUnwrapRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
         $edek = new Bytes("boo");
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->unwrapKey($edek, $metadata);
+        self::callMethod("unwrapKey", [$edek, $metadata]);
     }
 
     public function testFailedRekeyRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
         $edek = new Bytes("boo");
         $newTenantId = "foo";
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->rekey($edek, $newTenantId, $metadata);
+        self::callMethod("rekey", [$edek, $newTenantId, $metadata]);
     }
 
     public function testFailedBatchWrapRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->batchWrapKeys(["a", "2"], $metadata);
+        self::callMethod("batchWrapKeys", [["a", "2"], $metadata]);
     }
 
     public function testFailedBatchunWrapRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new RequestMetadata("tenant", new IclFields("foo"), []);
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->batchUnwrapKeys(["a" => new Bytes("edek1"), "2" => new Bytes("edek2")], $metadata);
+        self::callMethod("batchUnwrapKeys", [["a" => new Bytes("edek1"), "2" => new Bytes("edek2")], $metadata]);
     }
 
     public function testFailedLogSecurityEventRequest(): void
     {
-        $request = new TenantSecurityRequest("localhost:99999", "");
         $metadata = new EventMetadata("tenant", new IclFields("foo"), [], 1);
         $this->expectException(TenantSecurityException::class);
         $this->expectExceptionMessage("Failed to make a request to the TSP.");
-        $request->logSecurityEvent(UserEvent::login(), $metadata);
+        self::callMethod("logSecurityEvent", [UserEvent::login(), $metadata]);
     }
 }


### PR DESCRIPTION
- Added `final` to all the classes I could to prevent them from being extended
- Changed `Aes` to a `trait` since it's just a collection of static functions
- Changed `TenantSecurityRequest` methods to `protected` and made `TenantSecurityClient` extend it. This (and a comment on the class) is attempting to prevent SDK consumers from interacting with it directly.